### PR TITLE
Refactor spaCy loading with shared helper

### DIFF
--- a/job_specific_scorer.py
+++ b/job_specific_scorer.py
@@ -1,10 +1,9 @@
 import json
 import re
-import spacy
 from typing import Dict, List, Tuple
-from utils import clean_text
+from utils import clean_text, get_nlp
 
-nlp = spacy.load("en_core_web_sm")
+nlp = get_nlp()
 
 class JobSpecificScorer:
     def __init__(self):

--- a/matcher.py
+++ b/matcher.py
@@ -1,10 +1,9 @@
-import spacy
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
-from utils import RESUME_SECTIONS
+from utils import RESUME_SECTIONS, get_nlp
 from job_specific_scorer import JobSpecificScorer
 
-nlp = spacy.load("en_core_web_sm")
+nlp = get_nlp()
 
 def extract_keywords(text):
     """Extracts keywords (nouns, proper nouns, and noun chunks) from text."""

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,6 @@
 import re
+from functools import lru_cache
+import spacy
 
 RESUME_SECTIONS = [
     'contact information', 'summary', 'objective', 'experience',
@@ -9,3 +11,9 @@ RESUME_SECTIONS = [
 def clean_text(text):
     """Removes extra whitespace and lowercases text."""
     return re.sub(r'\s+', ' ', text).strip().lower()
+
+
+@lru_cache(maxsize=1)
+def get_nlp():
+    """Load and cache the spaCy English model."""
+    return spacy.load("en_core_web_sm")


### PR DESCRIPTION
## Summary
- add `get_nlp` helper to load and cache the spaCy model
- update matcher and job-specific scorer to use shared `get_nlp`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d737b07f48329a89997ad5aa5802c