### PR TITLE
Normalize resume sections with canonical mapping

### DIFF
--- a/matcher.py
+++ b/matcher.py
@@ -62,7 +62,7 @@ def analyze_resume(resume_text, job_desc_text, resume_sections, job_type="genera
             "skill_match_score": len(common_keywords) / len(job_desc_keywords) if job_desc_keywords else 0,
             "structure_score": job_specific_results.get('section_scores', {}),
             "missing_keywords": sorted(list(missing_keywords))[:10],
-            "present_sections": [s for s in RESUME_SECTIONS if resume_sections.get(s)],
+            "present_sections": [s for s in RESUME_SECTIONS.keys() if resume_sections.get(s)],
             "missing_sections": [s for s in ['experience', 'education', 'skills'] if s not in [k for k in resume_sections.keys() if resume_sections[k]]],
             "detailed_feedback": job_specific_results.get('detailed_feedback', []),
             "job_type": job_type,
@@ -84,7 +84,7 @@ def analyze_resume(resume_text, job_desc_text, resume_sections, job_type="genera
         skill_match_score = len(common_keywords) / len(job_desc_keywords) if job_desc_keywords else 0
 
         # 3. Structure Score (20%)
-        present_sections = [s for s in RESUME_SECTIONS if resume_sections.get(s)]
+        present_sections = [s for s in RESUME_SECTIONS.keys() if resume_sections.get(s)]
         # Give points for having key sections
         key_sections_present = sum(1 for s in ['experience', 'education', 'skills'] if s in present_sections)
         structure_score = key_sections_present / 3.0

--- a/parser.py
+++ b/parser.py
@@ -2,79 +2,76 @@ import re
 from pdfminer.high_level import extract_text
 from utils import RESUME_SECTIONS, clean_text
 
+
 def extract_text_from_pdf(pdf_file):
     """
     Extracts text from a PDF file-like object.
-    
+
     Args:
         pdf_file: A file-like object representing the PDF.
-        
+
     Returns:
         The extracted text as a string.
     """
     return extract_text(pdf_file)
 
+
 def extract_sections(text):
     """
     Extracts sections from resume text based on predefined section headers.
-    
+
     Args:
         text: The resume text.
-        
+
     Returns:
         A dictionary with section headers as keys and section content as values.
     """
     sections = {}
-    text_lines = text.split('\n')
+    text_lines = text.split("\n")
     current_section = None
     section_content = []
-    
-    # Enhanced section patterns
+
+    # Build regex patterns from the RESUME_SECTIONS mapping.
     section_patterns = {
-        'contact information': r'^\s*(contact|contact information|personal information)\s*$',
-        'summary': r'^\s*(summary|professional summary|executive summary|profile)\s*$',
-        'objective': r'^\s*(objective|career objective|professional objective)\s*$',
-        'experience': r'^\s*(experience|work experience|professional experience|employment|employment history)\s*$',
-        'education': r'^\s*(education|academic background|qualifications|academic qualifications)\s*$',
-        'skills': r'^\s*(skills|technical skills|core competencies|technologies|technical competencies)\s*$',
-        'projects': r'^\s*(projects|personal projects|side projects|portfolio|notable projects)\s*$',
-        'certifications': r'^\s*(certifications|certificates|professional certifications)\s*$'
+        canonical: r"^\s*(?:" + "|".join(re.escape(s) for s in synonyms) + r")\s*$"
+        for canonical, synonyms in RESUME_SECTIONS.items()
     }
-    
+
     for line in text_lines:
         line_stripped = line.strip()
         if not line_stripped:
             continue
-            
+
         # Check if this line is a section header
         section_found = None
         for section_name, pattern in section_patterns.items():
             if re.match(pattern, line_stripped, re.IGNORECASE):
                 section_found = section_name
                 break
-        
+
         if section_found:
             # Save previous section if it exists
             if current_section and section_content:
-                sections[current_section] = '\n'.join(section_content).strip()
-            
+                sections[current_section] = "\n".join(section_content).strip()
+
             # Start new section
             current_section = section_found
             section_content = []
         elif current_section:
             # Add content to current section
             section_content.append(line)
-    
+
     # Save the last section
     if current_section and section_content:
-        sections[current_section] = '\n'.join(section_content).strip()
-    
-    # Also check for implicit sections (for backward compatibility)
-    text_cleaned = clean_text(text)
-    for section in RESUME_SECTIONS:
-        if section not in sections:
-            match = re.search(r'\b' + section + r'\b', text, re.IGNORECASE)
-            if match:
-                sections[section] = True # Mark section as present
-    
+        sections[current_section] = "\n".join(section_content).strip()
+
+    # Also check for implicit sections using synonyms
+    for canonical, synonyms in RESUME_SECTIONS.items():
+        if canonical not in sections:
+            for synonym in synonyms:
+                if re.search(r"\b" + re.escape(synonym) + r"\b", text, re.IGNORECASE):
+                    sections[canonical] = True  # Mark section as present
+                    break
+
     return sections
+

--- a/test_parser.py
+++ b/test_parser.py
@@ -1,0 +1,14 @@
+from parser import extract_sections
+
+
+def test_extract_sections_uses_canonical_names():
+    text = (
+        "Work Experience\nDid stuff here\n\n"
+        "Technical Skills\nPython, Java\n"
+    )
+    sections = extract_sections(text)
+    assert "experience" in sections
+    assert "skills" in sections
+    assert "work experience" not in sections
+    assert "technical skills" not in sections
+

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,44 @@
 import re
 
-RESUME_SECTIONS = [
-    'contact information', 'summary', 'objective', 'experience',
-    'work experience', 'professional experience', 'education', 'skills',
-    'technical skills', 'certifications', 'projects'
-]
+# Mapping of canonical resume section names to their common synonyms. Each
+# canonical key should appear only once in the parsed output regardless of
+# which synonym is used in the resume.
+RESUME_SECTIONS = {
+    "contact information": ["contact", "contact information", "personal information"],
+    "summary": ["summary", "professional summary", "executive summary", "profile"],
+    "objective": ["objective", "career objective", "professional objective"],
+    "experience": [
+        "experience",
+        "work experience",
+        "professional experience",
+        "employment",
+        "employment history",
+    ],
+    "education": [
+        "education",
+        "academic background",
+        "qualifications",
+        "academic qualifications",
+    ],
+    "skills": [
+        "skills",
+        "technical skills",
+        "core competencies",
+        "technologies",
+        "technical competencies",
+    ],
+    "projects": [
+        "projects",
+        "personal projects",
+        "side projects",
+        "portfolio",
+        "notable projects",
+    ],
+    "certifications": ["certifications", "certificates", "professional certifications"],
+}
+
 
 def clean_text(text):
     """Removes extra whitespace and lowercases text."""
-    return re.sub(r'\s+', ' ', text).strip().lower()
+    return re.sub(r"\s+", " ", text).strip().lower()
+


### PR DESCRIPTION
## Summary
- map resume section headers to canonical names in `utils.py`
- update parser and matcher to use canonical section keys
- add test verifying canonicalization of section headers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d737705dc83299992c9c9468a45f6