### PR TITLE
Use section_scores for job-specific analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,13 @@ def display_results(analysis):
 
     with col2:
         st.info("Resume Structure")
+        if job_type == 'software_engineering':
+            section_scores = analysis.get('section_scores', {})
+            if isinstance(section_scores, dict) and section_scores:
+                st.markdown("**Section Scores:**")
+                for section, result in section_scores.items():
+                    score = result.get('score', 0) * 100
+                    st.markdown(f"- {section}: {score:.0f}%")
         if analysis['missing_sections']:
             st.warning(f"**Missing Sections:** {', '.join(analysis['missing_sections']).title()}")
         if analysis['present_sections']:

--- a/matcher.py
+++ b/matcher.py
@@ -60,7 +60,7 @@ def analyze_resume(resume_text, job_desc_text, resume_sections, job_type="genera
             "job_specific_score": job_specific_results['total_score'],
             "keyword_score": keyword_score,
             "skill_match_score": len(common_keywords) / len(job_desc_keywords) if job_desc_keywords else 0,
-            "structure_score": job_specific_results.get('section_scores', {}),
+            "section_scores": job_specific_results.get('section_scores', {}),
             "missing_keywords": sorted(list(missing_keywords))[:10],
             "present_sections": [s for s in RESUME_SECTIONS if resume_sections.get(s)],
             "missing_sections": [s for s in ['experience', 'education', 'skills'] if s not in [k for k in resume_sections.keys() if resume_sections[k]]],


### PR DESCRIPTION
## Summary
- Rename job-specific `structure_score` result to `section_scores`
- Display section-level scoring in UI for software engineering resumes

## Testing
- `python simple_test.py`
- `python test_scoring.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d735fe58c8329b3d4fc96fd1e26d9